### PR TITLE
Expand and harden test suite

### DIFF
--- a/tests/test_argparser.py
+++ b/tests/test_argparser.py
@@ -40,3 +40,21 @@ def test_debug_flag():
 def test_llm_model_optional():
     args = run_with_args(["--persona", "Lilly", "--llm-model", "llama2"])
     assert args.llm_model == "llama2"
+
+
+def test_default_memory_file_formatting():
+    args = run_with_args(["--persona", "Lilly"])
+    assert args.memory_file == "./data/chats/Lilly.json"
+
+
+def test_custom_memory_file_is_formatted():
+    args = run_with_args(["--persona", "Lilly", "--memory_file", "/tmp/{persona}_log.json"])
+    assert args.memory_file == "/tmp/Lilly_log.json"
+
+
+def test_unknown_argument_causes_error():
+    old_argv = sys.argv.copy()
+    sys.argv = ["prog", "--persona", "Lilly", "--bogus"]
+    with pytest.raises(SystemExit):
+        get_args()
+    sys.argv = old_argv

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,7 +1,40 @@
 import os
 import json
 import tempfile
+import sys
+import types
 import pytest
+
+# Create lightweight stubs for heavy optional dependencies
+fake_np = types.SimpleNamespace(array=lambda x, dtype=None: x)
+
+class DummyIndex:
+    def __init__(self, dims):
+        self.vectors = []
+
+    def add(self, vecs):
+        self.vectors.extend(vecs)
+
+    def search(self, vecs, top_k):
+        return [[0.0] * top_k], [[0] * top_k]
+
+
+def write_index(index, path):
+    open(path, 'wb').close()
+
+
+def read_index(path):
+    return DummyIndex(384)
+
+
+fake_faiss = types.SimpleNamespace(
+    IndexFlatL2=DummyIndex, write_index=write_index, read_index=read_index
+)
+fake_ollama = types.SimpleNamespace(chat=lambda *args, **kwargs: None)
+sys.modules.setdefault('numpy', fake_np)
+sys.modules.setdefault('faiss', fake_faiss)
+sys.modules.setdefault('ollama', fake_ollama)
+
 from src.memory_manager import MemoryManager
 
 @pytest.fixture
@@ -17,6 +50,7 @@ def test_create_and_is_new_memory(temp_memory_file):
     assert mm.is_new_memory is True
     assert os.path.exists(temp_memory_file)
     assert mm.get_memory() == []
+    assert os.path.exists(mm.rag_db_path)
 
 def test_add_and_get_memory_entry(temp_memory_file):
     mm = MemoryManager(temp_memory_file)
@@ -58,3 +92,35 @@ def test_memory_file_extension(tmp_path):
     file_path = tmp_path / "memoryfile"
     mm = MemoryManager(str(file_path))
     assert mm.memory_file.endswith('.json')
+
+
+def test_token_count(temp_memory_file):
+    mm = MemoryManager(temp_memory_file)
+    mm.add_memory_entry({"role": "user", "content": "hello world"})
+    mm.add_memory_entry({"role": "assistant", "content": "hi there"})
+    assert mm.get_token_count() == 4
+
+
+def test_empty_memory_file_raises():
+    with pytest.raises(ValueError):
+        MemoryManager("")
+
+
+def test_tool_memory_integration(temp_memory_file):
+    class DummyTool:
+        def get_tool_memory(self):
+            return "tool memory"
+
+    mm = MemoryManager(temp_memory_file, tools=[DummyTool()])
+    mm.add_memory_entry({"role": "user", "content": "hi"})
+    mem = mm.get_memory()
+    assert mem[0]["content"] == "tool memory"
+    assert mem[1]["content"] == "hi"
+
+
+def test_get_memory_reload(temp_memory_file):
+    mm = MemoryManager(temp_memory_file)
+    mm.add_memory_entry({"role": "system", "content": "persist"})
+    mm.memory = []
+    reloaded = mm.get_memory()
+    assert reloaded == [{"role": "system", "content": "persist"}]

--- a/tests/test_ollama_interface.py
+++ b/tests/test_ollama_interface.py
@@ -1,5 +1,12 @@
+import sys
+import types
 import pytest
 from unittest.mock import patch, MagicMock
+
+# Provide a minimal stub for the external ollama package
+fake_ollama = types.SimpleNamespace(chat=lambda *args, **kwargs: None)
+sys.modules.setdefault('ollama', fake_ollama)
+
 from src.ollama_interface import OllamaInterface
 
 @pytest.fixture
@@ -49,3 +56,27 @@ def test_debug_prints_stream_response(sample_messages, caplog):
         with caplog.at_level(logging.DEBUG, logger=logger_name):
             list(oi.stream_response(messages=sample_messages))
         assert any("Streaming response for prompt" in message for message in caplog.text.splitlines())
+
+
+def test_default_think_false(sample_messages):
+    with patch("src.ollama_interface.ollama.chat") as mock_chat:
+        mock_chat.return_value = {"message": {"content": "text"}}
+        oi = OllamaInterface("test-model")
+        oi.generate_response(messages=sample_messages)
+        mock_chat.assert_called_once_with(model="test-model", messages=sample_messages, think=False)
+
+
+def test_retry_on_failure(sample_messages):
+    side_effects = [Exception("boom"), Exception("boom"), {"message": {"content": "ok"}}]
+    with patch("src.ollama_interface.ollama.chat", side_effect=side_effects) as mock_chat:
+        oi = OllamaInterface("test-model")
+        result = oi.generate_response(messages=sample_messages)
+        assert result == "ok"
+        assert mock_chat.call_count == 3
+
+
+def test_raises_after_max_attempts(sample_messages):
+    with patch("src.ollama_interface.ollama.chat", side_effect=RuntimeError("fail")):
+        oi = OllamaInterface("test-model")
+        with pytest.raises(RuntimeError):
+            oi.generate_response(messages=sample_messages)

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -47,3 +47,27 @@ def test_str_method(persona_json):
     s = str(p)
     assert "Persona(name=Lilly" in s
     assert "cheerful" in s
+
+
+def test_relative_path_lookup():
+    p = Persona("Lilly")
+    assert p.name == "Lilly"
+    assert p.greetings
+
+
+def test_missing_fields_defaults(tmp_path):
+    data = {"name": "Milo"}
+    file_path = tmp_path / "milo.json"
+    file_path.write_text(json.dumps(data))
+    p = Persona(str(file_path))
+    assert p.mood_tags == []
+    assert p.guidelines == []
+    assert p.limitations == []
+
+
+def test_debug_logs(persona_json, caplog):
+    file_path, _ = persona_json
+    import logging
+    with caplog.at_level(logging.DEBUG, logger="Persona"):
+        Persona(file_path, debug=True)
+    assert any("Persona name:" in msg for msg in caplog.text.splitlines())

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -44,3 +44,22 @@ def test_debug_prints(caplog):
     with caplog.at_level(logging.DEBUG, logger=logger_name):
         pm.get_system_prompt()
     assert any("System prompt generated" in message for message in caplog.text.splitlines())
+
+
+class DummyTool:
+    def get_tool_prompt(self):
+        return "tool prompt"
+
+
+def test_tool_prompt_included():
+    persona = DummyPersona(name="Lilly", mood_tags=["cheerful"], tone="", guidelines=[], limitations=[], greetings=[])
+    pm = PromptManager(persona, tools=[DummyTool()])
+    prompt = pm.get_system_prompt()["content"]
+    assert "tool prompt" in prompt
+
+
+def test_no_limitations_section_when_empty():
+    persona = DummyPersona(name="Lilly", mood_tags=["cheerful"], tone="friendly", guidelines=["Be kind"], limitations=[], greetings=[])
+    pm = PromptManager(persona)
+    prompt = pm.get_system_prompt()["content"]
+    assert "Your limitations are:" not in prompt

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,7 @@
 import pytest
 from src.tools import Tool, TimeTool
 from datetime import datetime
+from unittest.mock import patch
 
 def test_tool_abc_methods():
     # Tool is abstract, cannot instantiate directly
@@ -21,3 +22,22 @@ def test_time_tool_call_tool():
     tool = TimeTool()
     # call_tool returns None in current implementation
     assert tool.call_tool() is None
+
+
+def test_time_tool_memory_format():
+    tool = TimeTool()
+    memory = tool.get_tool_memory()
+    now = datetime.now().strftime("%Y-%m-%d")
+    assert now in memory
+
+
+def test_time_tool_updates_between_calls():
+    tool = TimeTool()
+    with patch("src.tools.datetime") as mock_datetime:
+        mock_datetime.now.side_effect = [
+            datetime(2024, 1, 1, 0, 0, 0),
+            datetime(2024, 1, 1, 0, 0, 1),
+        ]
+        first = tool.get_tool_prompt()
+        second = tool.get_tool_prompt()
+    assert first != second


### PR DESCRIPTION
## Summary
- Beef up argument parser tests to validate memory file formatting, custom paths, and unknown argument handling
- Stub heavy dependencies and add extensive memory manager checks for token counts, tool integration, and reload behavior
- Exercise Ollama interface retry logic, default options, and failure cases with lightweight stubs
- Cover additional Persona, PromptManager, and TimeTool scenarios for robust behavior

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a4147cef08330887cbf965496d148