### PR TITLE
Add text-to-speech audio option

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,51 +4,95 @@ from src.ollama_interface import OllamaInterface
 from src.prompt_manager import PromptManager
 from src.memory_manager import MemoryManager
 from src.tools import TimeTool
+from src.tts_engine import synthesize
 import logging
 
-def main():
+
+def main() -> None:
+    """Run the interactive assistant."""
     args = get_args()
-    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO, filename='app.log', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        filename='app.log',
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    )
     logger = logging.getLogger("main")
     logger.info(f"Arguments received: {args}")
     if not args.llm_model:
         args.llm_model = "qwen3:4b"
-    ollama_interface = OllamaInterface(model_name=args.llm_model, debug=args.debug)
+    ollama_interface = OllamaInterface(
+        model_name=args.llm_model, debug=args.debug
+    )
     persona = Persona(args.persona, debug=args.debug)
     tools = [TimeTool()]
     prompt_manager = PromptManager(persona, tools, debug=args.debug)
     memory_manager = MemoryManager(args.memory_file, tools, debug=args.debug)
     system_prompt = prompt_manager.get_system_prompt()
     if memory_manager.is_new_memory:
-        greeting_messages = memory_manager.get_memory() + [system_prompt, {"role": "system", "content": f"It is the first time you meet the user. Greet them appropriately. You must introduce yourself as {persona.name}."}]
+        greeting_messages = memory_manager.get_memory() + [
+            system_prompt,
+            {
+                "role": "system",
+                "content": (
+                    f"It is the first time you meet the user. "
+                    f"Greet them appropriately. You must introduce "
+                    f"yourself as {persona.name}."
+                ),
+            },
+        ]
     else:
-        greeting_messages = memory_manager.get_memory() + [system_prompt, {"role": "system", "content": "The user has entered the chat. Greet them appropriately."}]
+        greeting_messages = memory_manager.get_memory() + [
+            system_prompt,
+            {
+                "role": "system",
+                "content": (
+                    "The user has entered the chat. "
+                    "Greet them appropriately."
+                ),
+            },
+        ]
     response = ""
-    for chunk in ollama_interface.stream_response(messages=greeting_messages, think=True):
-        print(f"{chunk}", end='', flush=True)
+    for chunk in ollama_interface.stream_response(
+        messages=greeting_messages, think=True
+    ):
+        print(f"{chunk}", end="", flush=True)
         response += chunk
     if args.debug:
         logger.debug("\n")
     memory_manager.add_memory_entry({"role": "assistant", "content": response})
-    print('\n')
+    if args.audio:
+        audio_path = synthesize(response, args.voice)
+        print(f"\n[Audio saved to {audio_path}]")
+    else:
+        print("\n")
     while True:
         user_input = input("You: ")
         if user_input.lower() in ["exit", "quit"]:
             print("Exiting the chat.")
             break
 
-        messages = memory_manager.get_memory() + [system_prompt, {"role": "user", "content": user_input}]
+        messages = memory_manager.get_memory() + [
+            system_prompt,
+            {"role": "user", "content": user_input},
+        ]
         memory_manager.add_memory_entry({"role": "user", "content": user_input})
 
         response = ""
-        print(f"Assistant: ", end='', flush=True)
-        for chunk in ollama_interface.stream_response(messages=messages, think=True):
-            print(f"{chunk}", end='', flush=True)
+        print("Assistant: ", end="", flush=True)
+        for chunk in ollama_interface.stream_response(
+            messages=messages, think=True
+        ):
+            print(f"{chunk}", end="", flush=True)
             response += chunk
         if args.debug:
             logger.debug("\n")
         memory_manager.add_memory_entry({"role": "assistant", "content": response})
-        print('\n')
+        if args.audio:
+            audio_path = synthesize(response, args.voice)
+            print(f"\n[Audio saved to {audio_path}]\n")
+        else:
+            print("\n")
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ faiss-cpu==1.11.0.post1
 sentence-transformers==5.0.0
 numpy==2.2.5
 # abc
+TTS
+playsound==1.3.0

--- a/src/argparser.py
+++ b/src/argparser.py
@@ -1,11 +1,22 @@
 import argparse
 
+
 def get_args():
     parser = argparse.ArgumentParser(description="Assaisonnement Interessant CLI")
-    parser.add_argument('--llm-model', type=str, default=None, help='Name of the LLM model to use (optional)')
-    parser.add_argument('--debug', action='store_true', help='Enable debug mode (optional)')
-    parser.add_argument('--persona', type=str, required=True, help='Persona to load (required)')
-    parser.add_argument('--memory_file', type=str, default='./data/chats/{persona}.json', help='Path to the memory file (optional, default: ./data/chats/{persona}.json)')
+    parser.add_argument('--llm-model', type=str, default=None,
+                        help='Name of the LLM model to use (optional)')
+    parser.add_argument('--debug', action='store_true',
+                        help='Enable debug mode (optional)')
+    parser.add_argument('--persona', type=str, required=True,
+                        help='Persona to load (required)')
+    parser.add_argument('--memory_file', type=str,
+                        default='./data/chats/{persona}.json',
+                        help='Path to the memory file (optional, '
+                             'default: ./data/chats/{persona}.json)')
+    parser.add_argument('--audio', action='store_true',
+                        help='Enable audio output (optional)')
+    parser.add_argument('--voice', type=str, default='default',
+                        help='Voice to use for audio output (optional)')
     # format the memory file path to include the persona name
     args = parser.parse_args()
     args.memory_file = args.memory_file.format(persona=args.persona)

--- a/src/tts_engine.py
+++ b/src/tts_engine.py
@@ -1,0 +1,75 @@
+"""Text-to-speech utilities using Coqui TTS."""
+from pathlib import Path
+import time
+from uuid import uuid4
+from typing import Dict, Iterable
+
+try:
+    from TTS.api import TTS  # type: ignore
+except Exception:  # pragma: no cover - handled in tests
+    TTS = None  # type: ignore
+
+try:
+    from playsound import playsound  # type: ignore
+except Exception:  # pragma: no cover - handled in tests
+    playsound = None  # type: ignore
+
+VOICE_MODELS: Dict[str, str] = {
+    "default": "tts_models/en/ljspeech/tacotron2-DDC",
+}
+
+LOG_DIR = Path("data/audio_logs")
+MAX_LOG_FILES = 3
+
+
+def play_audio(path: Path) -> None:
+    """Play an audio file.
+
+    Args:
+        path: Path to the WAV file.
+
+    Raises:
+        RuntimeError: If the playback library is unavailable.
+    """
+    if playsound is None:
+        raise RuntimeError("playsound library is not installed.")
+    playsound(str(path))
+
+
+def _prune_logs(files: Iterable[Path]) -> None:
+    """Remove old audio log files, keeping only the most recent ones."""
+    for old in files:
+        old.unlink()
+
+
+def synthesize(text: str, voice: str) -> Path:
+    """Synthesize speech from text and play it.
+
+    Args:
+        text: The text to convert to speech.
+        voice: The identifier of the voice to use.
+
+    Returns:
+        Path to the generated WAV file saved in the log directory.
+
+    Raises:
+        ValueError: If the text is empty or the voice is unknown.
+        RuntimeError: If the TTS or playback library is unavailable.
+    """
+    if not text.strip():
+        raise ValueError("Text must not be empty.")
+    if voice not in VOICE_MODELS:
+        raise ValueError(f"Unknown voice: {voice}")
+    if TTS is None:
+        raise RuntimeError("Coqui TTS library is not installed.")
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = int(time.time() * 1000)
+    file_path = LOG_DIR / f"{timestamp}_{uuid4().hex}.wav"
+    tts = TTS(VOICE_MODELS[voice])
+    tts.tts_to_file(text=text, file_path=str(file_path))
+    play_audio(file_path)
+    files = sorted(
+        LOG_DIR.glob("*.wav"), key=lambda p: p.stat().st_mtime, reverse=True
+    )
+    _prune_logs(files[MAX_LOG_FILES:])
+    return file_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_argparser.py
+++ b/tests/test_argparser.py
@@ -26,31 +26,48 @@ def test_minimal_args():
     assert args.persona == "Lilly"
     assert args.llm_model is None
     assert args.debug is False
+    assert args.audio is False
+    assert args.voice == "default"
 
 def test_all_args():
-    args = run_with_args(["--persona", "Lilly", "--llm-model", "qwen3:4b", "--debug"])
+    args = run_with_args([
+        "--persona", "Lilly",
+        "--llm-model", "qwen3:4b",
+        "--debug",
+        "--audio",
+        "--voice", "v1",
+    ])
     assert args.persona == "Lilly"
     assert args.llm_model == "qwen3:4b"
     assert args.debug is True
+    assert args.audio is True
+    assert args.voice == "v1"
 
 def test_debug_flag():
     args = run_with_args(["--persona", "Lilly", "--debug"])
     assert args.debug is True
 
+def test_audio_flag():
+    args = run_with_args(["--persona", "Lilly", "--audio"])
+    assert args.audio is True
+
 def test_llm_model_optional():
     args = run_with_args(["--persona", "Lilly", "--llm-model", "llama2"])
     assert args.llm_model == "llama2"
 
+def test_voice_option():
+    args = run_with_args(["--persona", "Lilly", "--voice", "alt"])
+    assert args.voice == "alt"
 
 def test_default_memory_file_formatting():
     args = run_with_args(["--persona", "Lilly"])
     assert args.memory_file == "./data/chats/Lilly.json"
 
-
 def test_custom_memory_file_is_formatted():
-    args = run_with_args(["--persona", "Lilly", "--memory_file", "/tmp/{persona}_log.json"])
+    args = run_with_args([
+        "--persona", "Lilly", "--memory_file", "/tmp/{persona}_log.json"
+    ])
     assert args.memory_file == "/tmp/Lilly_log.json"
-
 
 def test_unknown_argument_causes_error():
     old_argv = sys.argv.copy()

--- a/tests/test_tts_engine.py
+++ b/tests/test_tts_engine.py
@@ -1,0 +1,53 @@
+"""Tests for the text-to-speech engine."""
+from pathlib import Path
+from unittest.mock import patch
+import time
+
+import pytest
+
+from src import tts_engine
+
+
+def _fake_tts_to_file(text: str, file_path: str) -> None:
+    Path(file_path).write_bytes(b"audio")
+
+
+def test_synthesize_creates_file_and_plays_audio(tmp_path) -> None:
+    with (
+        patch.object(tts_engine, "TTS") as mock_tts,
+        patch.object(tts_engine, "play_audio") as mock_play,
+        patch.object(tts_engine, "LOG_DIR", tmp_path),
+    ):
+        mock_tts.return_value.tts_to_file.side_effect = _fake_tts_to_file
+        path = tts_engine.synthesize("hello", "default")
+        assert path.exists()
+        mock_play.assert_called_once_with(path)
+
+
+def test_synthesize_keeps_last_three_files(tmp_path) -> None:
+    with (
+        patch.object(tts_engine, "TTS") as mock_tts,
+        patch.object(tts_engine, "play_audio"),
+        patch.object(tts_engine, "LOG_DIR", tmp_path),
+    ):
+        mock_tts.return_value.tts_to_file.side_effect = _fake_tts_to_file
+        paths = []
+        for i in range(4):
+            paths.append(tts_engine.synthesize(f"hi {i}", "default"))
+            time.sleep(0.01)
+        remaining = list(tmp_path.glob("*.wav"))
+        assert len(remaining) == 3
+        assert paths[0] not in remaining
+        for path in paths[1:]:
+            assert path in remaining
+
+
+def test_unknown_voice_raises() -> None:
+    with pytest.raises(ValueError):
+        tts_engine.synthesize("hello", "unknown")
+
+
+def test_empty_text_raises() -> None:
+    with pytest.raises(ValueError):
+        tts_engine.synthesize("", "default")
+


### PR DESCRIPTION
## Summary
- add playback support and log retention to TTS engine
- include playsound dependency and relax Coqui TTS version pin
- extend TTS tests for audio playback and log pruning

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement TTS)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a70779b4883309b032f1c08d7c13a